### PR TITLE
[EDO-405] Remove virtual server resource from state if not found

### DIFF
--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -321,15 +321,15 @@ func resourceBigipLtmVirtualServerRead(ctx context.Context, d *schema.ResourceDa
 
 	vs, err := client.GetVirtualServer(name)
 	log.Printf("[DEBUG]virtual Server Details:%+v", vs)
-	if err != nil {
-		log.Printf("[ERROR] Unable to Retrieve Virtual Server  (%s) (%v)", name, err)
-		d.SetId("")
-		return diag.FromErr(err)
-	}
 	if vs == nil {
 		log.Printf("[WARN] VirtualServer (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		log.Printf("[ERROR] Unable to Retrieve Virtual Server  (%s) (%v)", name, err)
+		d.SetId("")
+		return diag.FromErr(err)
 	}
 	vsDest := vs.Destination
 	log.Printf("[DEBUG]vsDest :%+v", vsDest)


### PR DESCRIPTION
The current order of if statements wouldn't handle the case of manually deleted resource that TF needs to recreate