### PR TITLE
Fix provider crashing when an object has been deleted manually & fix SSL detection 

### DIFF
--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -197,14 +197,14 @@ func resourceBigipLtmNodeRead(ctx context.Context, d *schema.ResourceData, meta 
 	log.Println("[INFO] Fetching node " + name)
 
 	node, err := client.GetNode(name)
-	if err != nil {
-		log.Printf("[ERROR] Unable to retrieve node %s  %v :", name, err)
-		return diag.FromErr(err)
-	}
 	if node == nil {
 		log.Printf("[WARN] Node (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		log.Printf("[ERROR] Unable to retrieve node %s  %v :", name, err)
+		return diag.FromErr(err)
 	}
 	if node.FQDN.Name != "" {
 		_ = d.Set("address", node.FQDN.Name)
@@ -253,15 +253,15 @@ func resourceBigipLtmNodeExists(d *schema.ResourceData, meta interface{}) (bool,
 	log.Println("[INFO] Fetching node " + name)
 
 	node, err := client.GetNode(name)
+	if node == nil {
+		log.Printf("[WARN] node (%s) not found, removing from state", d.Id())
+		return false, nil
+	}
 	if err != nil {
 		log.Printf("[ERROR] Unable to retrieve node %s  %v :", name, err)
 		return false, err
 	}
 
-	if node == nil {
-		log.Printf("[WARN] node (%s) not found, removing from state", d.Id())
-		return false, nil
-	}
 	return true, nil
 }
 

--- a/bigip/resource_bigip_ltm_pool_attachment.go
+++ b/bigip/resource_bigip_ltm_pool_attachment.go
@@ -112,14 +112,14 @@ func resourceBigipLtmPoolAttachmentCreate(ctx context.Context, d *schema.Resourc
 	match := re.FindStringSubmatch(nodeName)
 	if match != nil {
 		node1, err := client.GetNode(parts[0])
-		if err != nil {
-			log.Printf("[ERROR] Unable to retrieve node %s  %v :", nodeName, err)
-			return diag.FromErr(err)
-		}
 		if node1 == nil {
 			log.Printf("[WARN] Node (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
+		}
+		if err != nil {
+			log.Printf("[ERROR] Unable to retrieve node %s  %v :", nodeName, err)
+			return diag.FromErr(err)
 		}
 		if node1.FQDN.Name != "" {
 			config := &bigip.PoolMemberFqdn{
@@ -182,13 +182,13 @@ func resourceBigipLtmPoolAttachmentUpdate(ctx context.Context, d *schema.Resourc
 	if match != nil {
 		parts := SplitNodePort(nodeName)
 		node1, err := client.GetNode(parts[0])
-		if err != nil {
-			return diag.FromErr(err)
-		}
 		if node1 == nil {
 			log.Printf("[WARN] Node (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
+		}
+		if err != nil {
+			return diag.FromErr(err)
 		}
 
 		poolMem := SplitNodePort(nodeName)[0]
@@ -303,23 +303,23 @@ func resourceBigipLtmPoolAttachmentRead(ctx context.Context, d *schema.ResourceD
 	expected := d.Get("node").(string)
 
 	pool, err := client.GetPool(poolName)
-	if err != nil {
-		log.Printf("[ERROR] Unable to Retrieve Pool (%s)  (%v) ", poolName, err)
-		return diag.FromErr(err)
-	}
 	if pool == nil {
 		log.Printf("[WARN] Pool (%s) not found, removing from state", poolName)
 		d.SetId("")
 		return nil
 	}
-	nodes, err := client.PoolMembers(poolName)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error retrieving pool (%s) members: %s", poolName, err))
+		log.Printf("[ERROR] Unable to Retrieve Pool (%s)  (%v) ", poolName, err)
+		return diag.FromErr(err)
 	}
+	nodes, err := client.PoolMembers(poolName)
 	if nodes == nil {
 		log.Printf("[WARN] Pool Members (%s) not found, removing from state", poolName)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error retrieving pool (%s) members: %s", poolName, err))
 	}
 	// only set the instance Id that this resource manages
 	found := false

--- a/bigip/resource_bigip_ltm_profile_http.go
+++ b/bigip/resource_bigip_ltm_profile_http.go
@@ -315,14 +315,14 @@ func resourceBigipLtmProfileHttpRead(ctx context.Context, d *schema.ResourceData
 	log.Println("[INFO] Fetching HTTP  Profile " + name)
 
 	pp, err := client.GetHttpProfile(name)
-	if err != nil {
-		log.Printf("[ERROR] Unable to retrieve HTTP Profile  (%s) ", err)
-		return diag.FromErr(err)
-	}
 	if pp == nil {
 		log.Printf("[WARN] HTTP  Profile (%s) not found, removing from state", name)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		log.Printf("[ERROR] Unable to retrieve HTTP Profile  (%s) ", err)
+		return diag.FromErr(err)
 	}
 	_ = d.Set("name", name)
 	_ = d.Set("defaults_from", pp.DefaultsFrom)

--- a/bigip/resource_bigip_ltm_profile_ssl_client.go
+++ b/bigip/resource_bigip_ltm_profile_ssl_client.go
@@ -570,16 +570,16 @@ func resourceBigipLtmProfileClientSSLRead(ctx context.Context, d *schema.Resourc
 	log.Println("[INFO] Fetching Client SSL Profile " + name)
 	obj, err := client.GetClientSSLProfile(name)
 
-	if err != nil {
-		log.Printf("[ERROR] Unable to Retrieve Client SSL Profile   (%s) (%v) ", name, err)
-		return diag.FromErr(err)
-	}
-
 	if obj == nil {
 		log.Printf("[WARN] Client SSL Profile (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		log.Printf("[ERROR] Unable to Retrieve Client SSL Profile   (%s) (%v) ", name, err)
+		return diag.FromErr(err)
+	}
+
 
 	_ = d.Set("name", name)
 	_ = d.Set("partition", obj.Partition)

--- a/bigip/resource_bigip_ltm_profile_ssl_server.go
+++ b/bigip/resource_bigip_ltm_profile_ssl_server.go
@@ -466,16 +466,16 @@ func resourceBigipLtmProfileServerSslRead(ctx context.Context, d *schema.Resourc
 	log.Println("[INFO] Fetching Server SSL Profile " + name)
 	obj, err := client.GetServerSSLProfile(name)
 
-	if err != nil {
-		log.Printf("[ERROR] Unable to Retrieve Server SSL Profile   (%s) (%v) ", name, err)
-		return diag.FromErr(err)
-	}
-
 	if obj == nil {
 		log.Printf("[WARN] Server SSL Profile (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		log.Printf("[ERROR] Unable to Retrieve Server SSL Profile   (%s) (%v) ", name, err)
+		return diag.FromErr(err)
+	}
+
 
 	_ = d.Set("name", name)
 	_ = d.Set("partition", obj.Partition)

--- a/bigip/resource_bigip_ltm_snatpool.go
+++ b/bigip/resource_bigip_ltm_snatpool.go
@@ -94,14 +94,14 @@ func resourceBigipLtmSnatpoolRead(ctx context.Context, d *schema.ResourceData, m
 	log.Println("[INFO] Fetching SNAT Pool " + name)
 
 	snatpool, err := client.GetSnatPool(name)
-	if err != nil {
-		log.Printf("[ERROR] Unable to Retrieve Snat Pool  (%s) (%v) ", name, err)
-		return diag.FromErr(err)
-	}
 	if snatpool == nil {
 		log.Printf("[WARN] SNAT Pool (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		log.Printf("[ERROR] Unable to Retrieve Snat Pool  (%s) (%v) ", name, err)
+		return diag.FromErr(err)
 	}
 	_ = d.Set("name", name)
 	_ = d.Set("members", snatpool.Members)

--- a/bigip/resource_bigip_ltm_virtual_address.go
+++ b/bigip/resource_bigip_ltm_virtual_address.go
@@ -113,14 +113,14 @@ func resourceBigipLtmVirtualAddressRead(ctx context.Context, d *schema.ResourceD
 
 	var va bigip.VirtualAddress
 	vas, err := client.VirtualAddresses()
-	if err != nil {
-		log.Printf("[ERROR] Unable to Retrieve Virtual Address (%s) (%v) ", name, err)
-		return diag.FromErr(err)
-	}
 	if vas == nil {
 		log.Printf("[WARN] VirtualAddress (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		log.Printf("[ERROR] Unable to Retrieve Virtual Address (%s) (%v) ", name, err)
+		return diag.FromErr(err)
 	}
 	for _, va = range vas.VirtualAddresses {
 		if va.FullPath == name {

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -321,15 +321,15 @@ func resourceBigipLtmVirtualServerRead(ctx context.Context, d *schema.ResourceDa
 
 	vs, err := client.GetVirtualServer(name)
 	log.Printf("[DEBUG]virtual Server Details:%+v", vs)
-	if err != nil {
-		log.Printf("[ERROR] Unable to Retrieve Virtual Server  (%s) (%v)", name, err)
-		d.SetId("")
-		return diag.FromErr(err)
-	}
 	if vs == nil {
 		log.Printf("[WARN] VirtualServer (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		log.Printf("[ERROR] Unable to Retrieve Virtual Server  (%s) (%v)", name, err)
+		d.SetId("")
+		return diag.FromErr(err)
 	}
 	vsDest := vs.Destination
 	log.Printf("[DEBUG]vsDest :%+v", vsDest)

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -457,15 +457,9 @@ func resourceBigipLtmVirtualServerRead(ctx context.Context, d *schema.ResourceDa
 				profileNames.Add(profile.FullPath)
 			}
 		}
-		if profileNames.Len() > 0 {
-			_ = d.Set("profiles", profileNames)
-		}
-		if clientProfileNames.Len() > 0 {
-			_ = d.Set("client_profiles", clientProfileNames)
-		}
-		if serverProfileNames.Len() > 0 {
-			_ = d.Set("server_profiles", serverProfileNames)
-		}
+		_ = d.Set("profiles", profileNames)
+		_ = d.Set("client_profiles", clientProfileNames)
+		_ = d.Set("server_profiles", serverProfileNames)
 	}
 	return nil
 }

--- a/bigip/resource_bigip_net_selfip.go
+++ b/bigip/resource_bigip_net_selfip.go
@@ -104,13 +104,13 @@ func resourceBigipNetSelfIPRead(ctx context.Context, d *schema.ResourceData, met
 	log.Printf("[INFO] Reading SelfIP %s", name)
 
 	selfIP, err := client.SelfIP(name)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("Error retrieving SelfIP %s: %v ", name, err))
-	}
 	if selfIP == nil {
 		log.Printf("[DEBUG] SelfIP %s not found, removing from state", name)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("Error retrieving SelfIP %s: %v ", name, err))
 	}
 
 	_ = d.Set("name", selfIP.FullPath)


### PR DESCRIPTION
- When no SSLs were left in the field, the provider completely ignored those fields. Now they are always being set which fixes the detection.
- Fix the statement order in all resources we use.